### PR TITLE
Feat/#67 ssl

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,5 +63,17 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             cd /home/ubuntu/Hamgaja
+            mkdir -p ssl
+      
+            cat > ssl/fullchain.pem << 'EOF'
+            ${{ secrets.SSL_FULLCHAIN }}
+            EOF
+      
+            cat > ssl/privkey.pem << 'EOF'
+            ${{ secrets.SSL_PRIVATE }}
+            EOF
+      
+            chmod 644 frontend/final-front/ssl/fullchain.pem
+            chmod 600 frontend/final-front/ssl/privkey.pem
             docker compose -f docker-compose.server.yml pull
             docker compose -f docker-compose.server.yml up -d

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+/final/Frontend/final-front/ssl/privkey.pem
+/final/Frontend/final-front/ssl/fullchain.pem
+/final/Frontend/final-front/ssl/chain.pem
+/final/Frontend/final-front/ssl/cert.pem

--- a/final/Frontend/final-front/.dockerignore
+++ b/final/Frontend/final-front/.dockerignore
@@ -1,0 +1,4 @@
+ssl/
+*.pem
+node_modules/
+.git/

--- a/final/Frontend/final-front/nginx.server.conf
+++ b/final/Frontend/final-front/nginx.server.conf
@@ -35,16 +35,16 @@ http {
 
     server {
         listen 80;
-        server_name localhost;
+        server_name hamgaja.click;
         return 301 https://$server_name$request_uri;  # HTTPS로 리다이렉트
     }
 
     server {
     listen 443 ssl;
-    server_name localhost;
+    server_name hamgaja.click;
 
-    ssl_certificate /etc/ssl/localhost+1.pem;
-    ssl_certificate_key /etc/ssl/localhost+1-key.pem;
+    ssl_certificate /etc/ssl/fullchain.pem;
+    ssl_certificate_key /etc/ssl/privkey.pem;
 
     # SSL 보안 설정
     ssl_protocols TLSv1.2 TLSv1.3;

--- a/final/docker-compose.release.yml
+++ b/final/docker-compose.release.yml
@@ -33,7 +33,7 @@ services:
     ports:
       - "8080:8080"  # 외부 8080 포트를 컨테이너 80 포트에 매핑
     volumes:
-      - ./Frontend/final-front/nginx.conf:/etc/nginx/nginx.conf # Nginx 설정 마운트
+      - ./Frontend/final-front/nginx.server.conf:/etc/nginx/nginx.conf # Nginx 설정 마운트
     depends_on:
       - backend
     networks:

--- a/final/docker-compose.yml
+++ b/final/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   backend:
     build:
-      context: ./backend
-      dockerfile: Backend/Dockerfile
+      context: ./Backend
+      dockerfile: Dockerfile
     container_name: spring-backend
     volumes:
       - gradle-cache:/root/.gradle  # Gradle 캐시 볼륨
@@ -29,8 +29,11 @@ services:
     container_name: vue-frontend
     restart: unless-stopped
     ports:
-      - "8080:8080"  # 외부 8080 포트를 컨테이너 80 포트에 매핑
+      - "8080:8080"
+      - "80:80"    # HTTP
+      - "443:443"  # HTTPS
     volumes:
+      - ./frontend/final-front/ssl:/etc/ssl:ro  # 읽기 전용으로 마운트
       - ./frontend/final-front/nginx.conf:/etc/nginx/nginx.conf # Nginx 설정 마운트
     depends_on:
       - backend


### PR DESCRIPTION
## **📌 Summary**

> SSL이 프로젝트에 추가되었습니다.

---

## **✅ Changes**

- [x]  Feature: 로컬 및 서버에서 이제 http가 아닌 https를 사용할 수 있습니다.

**Details:**

- mkcert를 통해 로컬에서 사용할 SSL 키를 발급받고, Let's encrypt로 route53에서 구매한 도메인에 맞는 인증 키를 발급받았습니다.
- 서버에서 사용할 도메인 키는 github secret으로 관리하기 때문에 github action의 CD 파이프라인에서만 작동합니다.
- Github action에 배포가 종속되는 문제가 있지만 scp로 키를 올리고 로컬에서 관리하고 하기엔 너무 번잡하기에 이 방법을 택했습니다.
- main에 push하는걸 트리거로 CD가 작동하기 때문에 테스트가 필요합니다.

---

## **🔗 Related Issue**

> Closes #67 

---

## **💬 Additional Notes**

> sql dump파일이 h2에서도 작동하도록 구현하는 방안을 고민중